### PR TITLE
feat: Remove Airdrop component from home-earth top section

### DIFF
--- a/src/sections/home-earth/components/top.tsx
+++ b/src/sections/home-earth/components/top.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { AnimatePresence, motion } from 'framer-motion';
-import Airdrop from '@/components/airdrop';
 import LGBTLogo from './lgbt-animated-logo';
 import { useActivityStore } from '@/stores/useActivityStore';
 import { useContext } from 'react';
@@ -83,7 +82,6 @@ const HomeEarthTop = (props: any) => {
           }
         </AnimatePresence>
       </div>
-      <Airdrop className="!left-[unset] right-0 !top-[150px]" />
     </div>
   );
 };


### PR DESCRIPTION
The Airdrop component is no longer rendered in the home-earth top section. This simplifies the layout and removes unused functionality from this part of the UI.