### PR TITLE
fix: Refactor vaults table to display unique pool projects

### DIFF
--- a/src/sections/vaults/v2/components/vaults-table/columns.tsx
+++ b/src/sections/vaults/v2/components/vaults-table/columns.tsx
@@ -14,6 +14,7 @@ import Link from "next/link";
 import { RewardIconContent } from "@/sections/vaults/v2/components/reward-icon";
 import { motion } from "framer-motion";
 import { useEffect, useRef } from "react";
+import { uniq } from 'lodash';
 
 export const Pool = (props: any) => {
   const { record, className } = props;
@@ -36,7 +37,9 @@ export const Pool = (props: any) => {
           />
         )}
       </div>
-      <div className="text-[12px]">{record.pool_project}</div>
+      <div className="text-[12px]">
+        {uniq(record.list.map((p: any) => p.pool_project)).join("/")}
+      </div>
     </div>
   );
 };

--- a/src/sections/vaults/v2/components/vaults-table/index.tsx
+++ b/src/sections/vaults/v2/components/vaults-table/index.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/sections/vaults/v2/components/vaults-table/columns';
 import { ORDER_DIRECTION, OrderKeys } from '@/sections/vaults/v2/config';
 import Pagination from "@/sections/vaults/v2/components/pagination";
+import { useMemo } from 'react';
 
 const VaultsTable = (props: any) => {
   const { className } = props;
@@ -23,11 +24,21 @@ const VaultsTable = (props: any) => {
     toggleListOrder
   } = useVaultsV2Context();
 
+  const VaultsWidth = useMemo(() => {
+    const maxIconLength = listDataGroupByPool
+      .reduce((max: any, item: any) => Math.max(max, item.protocolIcon.length), 0);
+
+    if (maxIconLength <= 2) return 60;
+    if (maxIconLength === 3) return 75;
+    if (maxIconLength === 4) return 90;
+    return 100;
+  }, [listDataGroupByPool]);
+
   const columns: any[] = [
     {
       title: "Vaults",
       dataIndex: "vaults",
-      width: 75,
+      width: VaultsWidth,
       render: (text: any, record: any, index: any) => {
         return <Vaults record={record} index={index} />;
       }


### PR DESCRIPTION
Replaced static pool project display with a dynamic list of unique projects using Lodash's `uniq` function. This ensures clearer information presentation when multiple pool projects are associated.