### PR TITLE
[⚠️ DO NOT MERGE NOW] fix: Add support for formatting additional action parameters

### DIFF
--- a/src/hooks/use-add-action.ts
+++ b/src/hooks/use-add-action.ts
@@ -87,6 +87,10 @@ export default function useAddAction(source: string, isNear = false) {
           )} ${data.token.symbol} on ${data.template}`;
           params.action_tokens = JSON.stringify([`${data.token.symbol}`]);
           params.action_amount = data.amount;
+          // for beraborrow
+          if (data.extra_data) {
+            params.extra_data = JSON.stringify(data.extra_data);
+          }
         }
       }
       if (data.type === "Liquidity") {

--- a/src/sections/Lending/Beraborrow/form.tsx
+++ b/src/sections/Lending/Beraborrow/form.tsx
@@ -459,6 +459,28 @@ export const Form = (props: any) => {
             addAction={addAction}
             addActionText={buttonValid.actions[0]}
             addActionToken={buttonValid.actionTokens[0]}
+            addActionParamsFormatter={(addActionParams) => {
+              const _addActionParams: any = {
+                ...addActionParams,
+                extra_data: {},
+              };
+              for (let i = 0; i < buttonValid.actions.length; i++) {
+                const ac = buttonValid.actions[i];
+                if (ac === "Deposit") {
+                  _addActionParams.extra_data.deposit_amount = buttonValid.actionAmounts[i];
+                }
+                if (ac === "Borrow") {
+                  _addActionParams.extra_data.borrow_amount = buttonValid.actionAmounts[i];
+                }
+                if (ac === "Withdraw") {
+                  _addActionParams.extra_data.withdraw_amount = buttonValid.actionAmounts[i];
+                }
+                if (ac === "Repay") {
+                  _addActionParams.extra_data.repay_amount = buttonValid.actionAmounts[i];
+                }
+              }
+              return _addActionParams;
+            }}
           >
             {buttonValid.text}
           </LendingButton>


### PR DESCRIPTION
Introduced a `addActionParamsFormatter` prop to customize the handling of additional parameters for lending actions. Extended support for handling `extra_data` in the transaction payload, enabling better flexibility for specific use cases like beraborrow.