### PR TITLE
fix: Set item ID to pool_address instead of extra_data.pool_id

### DIFF
--- a/src/sections/vaults/v2/hooks/list.ts
+++ b/src/sections/vaults/v2/hooks/list.ts
@@ -425,7 +425,7 @@ export function useList(): List {
           item.creatorProtocolIcon = getDappLogo(item.creator_project);
           item.lpProtocol = item.pool_project;
           item.backendId = item.id;
-          item.id = item.extra_data.pool_id;
+          item.id = item.pool_address;
           item.balance = item.user_stake?.usd;
           item.vaultAddress = item.vault_address;
 

--- a/src/sections/vaults/v2/hooks/list.ts
+++ b/src/sections/vaults/v2/hooks/list.ts
@@ -378,7 +378,7 @@ export function useList(): List {
           item.user_stake = item.user_stake || {};
 
           item.tokens.forEach((token: any) => {
-            token.icon = getTokenLogo(token.symbol);
+            token.icon = getTokenLogo(token.symbol?.replace(/\s/g, ""));
           });
           item.reward_tokens.forEach((token: any) => {
             token.icon = getTokenLogo(token.symbol);


### PR DESCRIPTION
Previously, the item ID was assigned using extra_data.pool_id. This change ensures that the correct identifier, pool_address, is used for better consistency and accuracy.