### PR TITLE
fix: Remove "Mint LP" button for BurrBear protocol

### DIFF
--- a/src/sections/vaults/v2/components/action/union/position.tsx
+++ b/src/sections/vaults/v2/components/action/union/position.tsx
@@ -49,18 +49,25 @@ const ActionUnionPotions = (props: any) => {
               .join("-")}
           </div>
         </div>
-        {["Bex", "Kodiak", "BurrBear"].includes(currentProtocol.lpProtocol) &&
-          actionType.value === ACTION_TYPE.DEPOSIT && (
-            <button
-              type="button"
-              className="flex justify-center items-center w-[148px] h-[46px] flex-shrink-0 rounded-[10px] border border-[#000] bg-[#FFDC50] text-[#000] text-center font-Montserrat text-[18px] font-semibold leading-[90%]"
-              onClick={() => {
-                toggleOpenAddLp(true);
-              }}
-            >
-              Mint LP
-            </button>
-          )}
+        {
+          [
+            "Bex",
+            "Kodiak",
+            // ⚠️@Bob#14:56 2025-04-16 Remove the button of Mint LP witch protocol is BurrBear
+            // "BurrBear"
+          ].includes(currentProtocol.lpProtocol) &&
+            actionType.value === ACTION_TYPE.DEPOSIT && (
+              <button
+                type="button"
+                className="flex justify-center items-center w-[148px] h-[46px] flex-shrink-0 rounded-[10px] border border-[#000] bg-[#FFDC50] text-[#000] text-center font-Montserrat text-[18px] font-semibold leading-[90%]"
+                onClick={() => {
+                  toggleOpenAddLp(true);
+                }}
+              >
+                Mint LP
+              </button>
+          )
+        }
         {["D2 Finance"].includes(currentProtocol.lpProtocol) &&
           actionType.value === ACTION_TYPE.DEPOSIT && (
             <button


### PR DESCRIPTION
The "Mint LP" button is no longer rendered for the BurrBear protocol during deposit actions. This change aligns with updated requirements and prevents unintended interactions for this specific protocol.