### PR TITLE
fix: Update reward weights to handle missing metadata gracefully

### DIFF
--- a/src/sections/bgt/validator/components/reward-weights.tsx
+++ b/src/sections/bgt/validator/components/reward-weights.tsx
@@ -3,7 +3,7 @@ import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Sector } from 'recha
 import { useMemo, useState } from 'react';
 import Big from 'big.js';
 import { numberFormatter } from '@/utils/number-formatter';
-import { getProtocolIcon } from '@/utils/utils';
+import { formatLongText, getProtocolIcon } from '@/utils/utils';
 
 const renderActiveShape = (props: any) => {
   const { cx, cy, innerRadius, outerRadius, startAngle, endAngle, fill } = props;
@@ -35,10 +35,10 @@ const RewardWeights = (props: any) => {
     const _totalBGT = vaults.reduce((acc: any, curr: any) => Big(acc).plus(Big(pageData?.dynamicData?.rewardRate ?? 0).times(Big(curr?.percentageNumerator ?? 0).div(10000))), Big(0));
     return vaults.map((item: any) => ({
       value: Big(pageData?.dynamicData?.rewardRate ?? 0).times(Big(item?.percentageNumerator ?? 0).div(10000)).div(_totalBGT).times(100).toNumber(),
-      name: item.receivingVault?.metadata?.name,
-      icon: item.receivingVault?.metadata?.logoURI,
+      name: item.receivingVault?.metadata?.name ?? formatLongText(item.receivingVault?.id, 4, 4),
+      icon: item.receivingVault?.metadata?.logoURI ?? "/images/bgt-logo.svg",
       cornerIcon: getProtocolIcon(item.receivingVault?.metadata?.protocolName),
-      protocol: item.receivingVault?.metadata?.protocolName,
+      protocol: item.receivingVault?.metadata?.protocolName ?? "OTHER",
     }));
   }, [vaults]);
 

--- a/src/sections/vaults/v2/components/aggregating.tsx
+++ b/src/sections/vaults/v2/components/aggregating.tsx
@@ -108,7 +108,7 @@ const Aggregating = (props: any) => {
                 key={idx}
                 offset={20}
                 content={dapp.message.title ? (
-                  <div className="w-[300px] h-[280px] bg-[url('/images/vaults/v2/berachain-logo.svg')] bg-no-repeat bg-center bg-[length:169px_82px] py-[30px] px-[20px] rotate-[3deg] shrink-0 border border-[#847B36] bg-[#FFF5A9] shadow-[6px_14px_0px_0px_rgba(0,_0,_0,_0.25)] font-Fuzzy text-black text-[15px] font-normal leading-[150%]">
+                  <div className="w-[300px] bg-[url('/images/vaults/v2/berachain-logo.svg')] bg-no-repeat bg-center bg-[length:169px_82px] py-[20px] px-[20px] rotate-[3deg] shrink-0 border border-[#847B36] bg-[#FFF5A9] shadow-[6px_14px_0px_0px_rgba(0,_0,_0,_0.25)] font-Fuzzy text-black text-[15px] font-normal leading-[150%]">
                     <div className="line-clamp-5">
                       '{dapp.message.content}'
                     </div>

--- a/src/sections/vaults/v2/components/aggregating.tsx
+++ b/src/sections/vaults/v2/components/aggregating.tsx
@@ -108,7 +108,7 @@ const Aggregating = (props: any) => {
                 key={idx}
                 offset={20}
                 content={dapp.message.title ? (
-                  <div className="w-[300px] bg-[url('/images/vaults/v2/berachain-logo.svg')] bg-no-repeat bg-center bg-[length:169px_82px] py-[20px] px-[20px] rotate-[3deg] shrink-0 border border-[#847B36] bg-[#FFF5A9] shadow-[6px_14px_0px_0px_rgba(0,_0,_0,_0.25)] font-Fuzzy text-black text-[15px] font-normal leading-[150%]">
+                  <div className="w-[300px] bg-[url('/images/vaults/v2/berachain-logo.svg')] bg-no-repeat bg-center bg-[length:169px_82px] pt-[30px] pb-[20px] px-[20px] rotate-[3deg] shrink-0 border border-[#847B36] bg-[#FFF5A9] shadow-[6px_14px_0px_0px_rgba(0,_0,_0,_0.25)] font-Fuzzy text-black text-[15px] font-normal leading-[150%]">
                     <div className="line-clamp-5">
                       '{dapp.message.content}'
                     </div>


### PR DESCRIPTION
Introduced fallback values for vault metadata to ensure proper UI rendering when data is missing. `formatLongText` was utilized for fallback naming, default icons and protocol names were added to prevent null values.